### PR TITLE
Exclude js_on field from Perch form submission

### DIFF
--- a/perch/addons/apps/impeng_cleantalk/runtime.php
+++ b/perch/addons/apps/impeng_cleantalk/runtime.php
@@ -111,7 +111,7 @@ function impeng_cleantalk_form_handler($SubmittedForm) {
 
         }
         // prevent passing on js_on field
-        $data['js_on'] = "";
+        unset($SubmittedForm->data['js_on']);
         //Redispatch all submitted forms to Perch forms regardless of enabled/disabled and CleanTalk result
         $SubmittedForm->redispatch('perch_forms');
 


### PR DESCRIPTION
If I’m understanding this line correctly, it’s meant to prevent the hidden `js_on field` from being passed onto Perch. From what I'm seeing this isn’t happening, as the field is still listed in the form entries in the CP, as well as being included on the plain text email template. This should fix that.